### PR TITLE
Add tour test for free delivery charges over certain amount

### DIFF
--- a/addons/website_sale_delivery/static/src/js/website_free_delivery_tour.js
+++ b/addons/website_sale_delivery/static/src/js/website_free_delivery_tour.js
@@ -1,0 +1,36 @@
+odoo.define('website_sale_delivery.tour', function (require) {
+'use strict';
+
+var base = require('web_editor.base');
+var tour = require("web_tour.tour");
+
+tour.register('check_free_delivery', {
+        test: true,
+        url: '/shop?search=conference chair',
+        wait_for: base.ready(),
+},
+    [
+        {
+            content: "select conference chair",
+            trigger: '.oe_product_cart:first a:contains("Conference Chair")',
+        },
+        {
+            content: "click on add to cart",
+            extra_trigger: 'label:contains(Steel) input:propChecked',
+            trigger: '#product_detail form[action^="/shop/cart/update"] .btn-primary',
+        },
+        {
+            content: "click in modal on 'Proceed to checkout' button",
+            trigger: 'button:contains("Proceed to Checkout")',
+        },
+        {
+            content: "go to checkout",
+            extra_trigger: '#cart_products input.js_quantity:propValue(1)',
+            trigger: 'a[href*="/shop/checkout"]',
+        },
+        {
+            content: "Check Free Delivery value to be zero",
+            trigger: "#delivery_carrier span:contains('0.0')"
+        },
+    ]);
+});

--- a/addons/website_sale_delivery/tests/__init__.py
+++ b/addons/website_sale_delivery/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_ui

--- a/addons/website_sale_delivery/tests/test_ui.py
+++ b/addons/website_sale_delivery/tests/test_ui.py
@@ -1,0 +1,14 @@
+import odoo.tests
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestUi(odoo.tests.HttpCase):
+
+    def test_01_free_delivery_when_exceed_threshold(self):
+        self.env.ref("delivery.free_delivery_carrier").write({
+            'fixed_price': 2,
+            'free_over': True,
+            'amount': 10,
+        })
+        self.phantom_js("/web", "odoo.__DEBUG__.services['web_tour.tour'].run('check_free_delivery')", "odoo.__DEBUG__.services['web_tour.tour'].tours.check_free_delivery.ready", login="admin")

--- a/addons/website_sale_delivery/views/website_sale_delivery_templates.xml
+++ b/addons/website_sale_delivery/views/website_sale_delivery_templates.xml
@@ -22,6 +22,12 @@
       </xpath>
     </template>
 
+    <template id="assets_common" name="Website Sale Common Assets" inherit_id="web.assets_common">
+      <xpath expr="." position="inside">
+        <script type="text/javascript" src="/website_sale_delivery/static/src/js/website_free_delivery_tour.js"></script>
+      </xpath>
+    </template>
+
     <template id="payment_delivery_methods">
         <input t-att-value="delivery.id" t-att-id="'delivery_%i' % delivery.id" type="radio" name="delivery_type" t-att-checked="order.carrier_id and order.carrier_id.id == delivery.id and 'checked' or False" t-att-class="'d-none' if delivery_nb == 1 else ''"/>
         <label class="label-optional" t-field="delivery.name" t-att-for="'delivery_%i' % delivery.id"/>

--- a/doc/cla/corporate/jankaritech.md
+++ b/doc/cla/corporate/jankaritech.md
@@ -1,0 +1,23 @@
+Nepal, 21.05.2019
+
+JankariTech Pvt. Ltd. agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Artur Neumann artur@jankaritech.com https://github.com/individual-it
+
+List of contributors:
+
+Artur Neumann artur@jankaritech.com https://github.com/individual-it
+
+Phil Davis phil@jankaritech.com https://github.com/phil-davis
+
+Paurakh Sharma Humagain paurakh011@gmail.com https://github.com/paurakhsharma
+
+Saugat Pachhai suagatchhetri@outlook.com https://github.com/skshetry
+
+Dipak Acharya dpakach@gmail.com https://github.com/dpakach


### PR DESCRIPTION
This PR adds a tour for the condition where the delivery charges, even though,
was not added to the charges, was shown in the delivery charges aside (even if the payment
was over the amount where free delivery was available). This adds a test that it should be
"0.0" instead. Was tested before the fix and after the fix.

### How to test
1. Clone this repo and setup odoo.
2.`./odoo-bin -i website_sale_delivery  --test-tags website_sale_delivery -d minimal_database --test-enable --stop-after-init -p 1234`
3. It should pass. 
4. Fetch and checkout to `test-free-delivery-before-fix` on this repo, and rerun step 2. It should fail (error code should be returned, check via `echo $?`). If it fails, test video and image where it failed is made available (in the root of this repo).

### Comment on the test code
1. Currently, the `rpc` call is done inside `js` rather than inside testcases.
2. Most of the steps were reused from the below file, and can be shortened:
https://github.com/jankaritech/odoo/blob/070bd40f64da3b16fbfce42de867aaf9e149d64a/addons/website_sale/static/src/js/website_sale_tour_buy.js
