### PR TITLE
Add tour for creating new note and editing it

### DIFF
--- a/addons/note/static/src/js/tour.js
+++ b/addons/note/static/src/js/tour.js
@@ -1,0 +1,59 @@
+odoo.define('note.tour', function (require) {
+'use strict';
+
+var base = require('web_editor.base');
+var tour = require('web_tour.tour');
+
+tour.register('note_tour', {
+        test: true,
+        url: '/web',
+        wait_for: base.ready(),
+},
+    [
+        tour.STEPS.SHOW_APPS_MENU_ITEM,
+        {
+            content: "Create notes here",
+            trigger: '.o_app[data-menu-xmlid="note.menu_note_notes"]',
+        },
+        {
+            content: "Add a new note",
+            trigger: '.btn-primary.o-kanban-button-new',
+        },
+        {
+            content: "Write the description about your note",
+            extra_trigger: '.note-editing-area',
+            trigger: '.note-editing-area p',
+            run: 'text Awesome Note'
+        },
+        {
+            content: "Save your note",
+            trigger: '.btn-primary.o_form_button_save',
+        },
+        {
+            content: "View all of your notes",
+            trigger: '.o_menu_brand',
+        },
+        {
+            content: "Edit the note you just created",
+            trigger: '.oe_kanban_content span:contains("Awesome Note")',
+        },
+        {
+            content: "Write the description about your note",
+            extra_trigger: '.note-editing-area',
+            trigger: '.note-editing-area p',
+            run: 'text Super Awesome Note'
+        },
+        {
+            content: "Save your changes on the note",
+            trigger: '.btn-primary.o_form_button_save',
+        },
+        {
+            content: "Go back to view all of your notes",
+            trigger: '.o_menu_brand',
+        },
+        {
+            content: "The edited note is saved here",
+            trigger: '.oe_kanban_content span:contains("Super Awesome Note")',
+        }
+    ]);
+});

--- a/addons/note/tests/__init__.py
+++ b/addons/note/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_note
+from . import test_ui

--- a/addons/note/tests/test_ui.py
+++ b/addons/note/tests/test_ui.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestUi(odoo.tests.HttpCase):
+
+    def test_01_create_and_edit_note(self):
+        self.phantom_js("/web", "odoo.__DEBUG__.services['web_tour.tour'].run('note_tour')", "odoo.__DEBUG__.services['web_tour.tour'].tours.note_tour.ready", login="admin")

--- a/addons/note/views/note_templates.xml
+++ b/addons/note/views/note_templates.xml
@@ -14,4 +14,10 @@
             <script type="text/javascript" src="/note/static/tests/systray_activity_menu_tests.js"></script>
         </xpath>
     </template>
+
+    <template id="assets_common" name="Note Common assets" inherit_id="web.assets_common">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/note/static/src/js/tour.js"></script>
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Add tour/test for note app.
Test if the user can create a new note and edit existing note.

Current behavior before PR:
There is no tour for the note module hence no way to quickly verify that the modules work.

Desired behavior after PR is merged:
The note module needs tours that also help to test it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
